### PR TITLE
Changed uri to return vault_uri instead of id

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -4,7 +4,7 @@ output "id" {
 }
 
 output "uri" {
-  value       = azurerm_key_vault.main.id
+  value       = azurerm_key_vault.main.vault_uri
   description = "The URI of the Key Vault."
 }
 


### PR DESCRIPTION
The `output "id"` already returned id, so changed the `output "uri"` to return the vault_uri instead